### PR TITLE
Fix: Added missing contact mapping in PatientDTO conversion

### DIFF
--- a/src/main/java/com/Major/Project/Patient/Service/PatientService.java
+++ b/src/main/java/com/Major/Project/Patient/Service/PatientService.java
@@ -55,6 +55,7 @@ public class PatientService {
         patientDTO.setName(patient.getName());
         patientDTO.setAge(patient.getAge());
         patientDTO.setGender(patient.getGender());
+        patientDTO.setContact(patient.getContact());
         if(patient.getAppointments()!=null){
             patientDTO.setAppointmentIds(patient.getAppointments().stream()
                     .map(a->a.getAppointmentId())


### PR DESCRIPTION
## 📌 Reason for Change
Previously, the contact number field in `PatientDTO` was always `null` after retrieval,  
even though it was stored correctly in the database.  
This was due to the mapping omission during DTO conversion.

## ✅ Result
- `GET` requests for patient data now return the correct contact number.
- No impact on other fields or existing functionality.
