### PR TITLE
Implement role-based access control (Admin, Doctor, Patient) for API endpoints #64

### DIFF
--- a/src/main/java/com/Major/Project/Controller/AppointmentController.java
+++ b/src/main/java/com/Major/Project/Controller/AppointmentController.java
@@ -1,52 +1,65 @@
-package com.Major.Project.Controller;
+    package com.Major.Project.Controller;
 
-import com.Major.Project.Entity.Appointment;
-import com.Major.Project.Service.AppointmentService;
-import com.Major.Project.DTO.AppointmentDTO;
+    import com.Major.Project.Entity.Appointment;
+    import com.Major.Project.Service.AppointmentService;
+    import com.Major.Project.DTO.AppointmentDTO;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+    import org.springframework.beans.factory.annotation.Autowired;
+    import org.springframework.http.ResponseEntity;
+    import org.springframework.security.access.prepost.PreAuthorize;
+    import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+    import java.util.List;
 
-@RestController
-@RequestMapping("/HMS/Appointment")
-public class AppointmentController {
+    @RestController
+    @RequestMapping("/HMS/Appointment")
+    public class AppointmentController {
 
-    @Autowired
-    private AppointmentService appointmentService;
+        @Autowired
+        private AppointmentService appointmentService;
 
-    @GetMapping
-    public List<AppointmentDTO> getAllAppointment(){
-        return appointmentService.getAppointments();
+        @PreAuthorize("hasRole('DOCTOR') or hasRole('PATIENT')")
+        @GetMapping
+        public List<AppointmentDTO> getAllAppointment(){
+            return appointmentService.getAppointments();
+        }
+
+        @PreAuthorize("hasRole('DOCTOR') or hasRole('PATIENT')")
+        @GetMapping("/{id}")
+        public AppointmentDTO getAppointmentById(@PathVariable Long id){
+            return appointmentService.getAppointmentById(id);
+        }
+
+        @PreAuthorize("hasRole('DOCTOR') or hasRole('PATIENT')")
+        @PostMapping
+        public AppointmentDTO createAppointment(@RequestBody Appointment appointment){
+            return appointmentService.createAppointment(appointment);
+        }
+
+        @PreAuthorize("hasRole('DOCTOR') or hasRole('PATIENT')")
+        @DeleteMapping("/{id}")
+        public ResponseEntity<Void> DeleteAppointment(@PathVariable Long id){
+            appointmentService.deleteAppointment(id);
+            return ResponseEntity.noContent().build();
+        }
+
+        @PreAuthorize("hasRole('DOCTOR') or hasRole('PATIENT')")
+        @PutMapping("/{id}")
+        public ResponseEntity<AppointmentDTO> updateAppointment(@PathVariable Long id,@RequestBody Appointment appointment ){
+            AppointmentDTO updated = appointmentService.updateAppointment(id, appointment);
+            return updated != null ? ResponseEntity.ok(updated) : ResponseEntity.notFound().build();
+        }
+
+        @PreAuthorize("hasRole('DOCTOR')")
+        @GetMapping("/doctor/{doctorId}")
+        public List<AppointmentDTO> getByDoctor(@PathVariable Long doctorId) {
+            return appointmentService.findByDoctorId(doctorId);
+        }
+
+        @PreAuthorize("hasRole('DOCTOR') or hasRole('PATIENT')")
+        @GetMapping("/patient/{patientId}")
+        public List<AppointmentDTO> getByPatient(@PathVariable Long patientId) {
+            return appointmentService.findByPatientId(patientId);
+        }
+
     }
-    @GetMapping("/{id}")
-    public AppointmentDTO getAppointmentById(@PathVariable Long id){
-        return appointmentService.getAppointmentById(id);
-    }
-    @PostMapping
-    public AppointmentDTO createAppointment(@RequestBody Appointment appointment){
-        return appointmentService.createAppointment(appointment);
-    }
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> DeleteAppointment(@PathVariable Long id){
-        appointmentService.deleteAppointment(id);
-        return ResponseEntity.noContent().build();
-    }
-    @PutMapping("/{id}")
-    public ResponseEntity<AppointmentDTO> updateAppointment(@PathVariable Long id,@RequestBody Appointment appointment ){
-        AppointmentDTO updated = appointmentService.updateAppointment(id, appointment);
-        return updated != null ? ResponseEntity.ok(updated) : ResponseEntity.notFound().build();
-    }
-    @GetMapping("/doctor/{doctorId}")
-    public List<AppointmentDTO> getByDoctor(@PathVariable Long doctorId) {
-        return appointmentService.findByDoctorId(doctorId);
-    }
-
-    @GetMapping("/patient/{patientId}")
-    public List<AppointmentDTO> getByPatient(@PathVariable Long patientId) {
-        return appointmentService.findByPatientId(patientId);
-    }
-
-}

--- a/src/main/java/com/Major/Project/Controller/BillController.java
+++ b/src/main/java/com/Major/Project/Controller/BillController.java
@@ -5,6 +5,7 @@ import com.Major.Project.Entity.Bill;
 import com.Major.Project.Service.BillService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -14,28 +15,40 @@ import java.util.List;
 public class BillController {
     @Autowired
     private BillService billService;
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('DOCTOR') or hasRole('PATIENT')")
     @GetMapping
     public List<BillDTO> getAllBill(){
         return billService.getAllBill();
     }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('DOCTOR') or hasRole('PATIENT')")
     @GetMapping("/{id}")
     public ResponseEntity<BillDTO> getBillById(@PathVariable Long id){
         BillDTO bill = billService.getBillById(id);
         return bill != null ? ResponseEntity.ok(bill) : ResponseEntity.notFound().build();
     }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('DOCTOR') or hasRole('PATIENT')")
     @GetMapping("/Patient/{patientId}")
     public List<BillDTO> getBillByPatientID(@PathVariable Long patientId){
         return billService.getBillByPatient(patientId);
     }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('DOCTOR')")
     @PostMapping
     public BillDTO CreateBill(@RequestBody Bill bill){
         return billService.createBill(bill);
     }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('DOCTOR'))")
     @PutMapping("/{id}")
     public ResponseEntity<BillDTO> updateBill(@PathVariable Long id,@RequestBody Bill bill){
       BillDTO updated=  billService.UpdateBill(id,bill);
        return updated != null ? ResponseEntity.ok(updated) : ResponseEntity.notFound().build();
     }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('DOCTOR'))")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteBill(@PathVariable Long id){
        billService.deleteBill(id);

--- a/src/main/java/com/Major/Project/Controller/DoctorController.java
+++ b/src/main/java/com/Major/Project/Controller/DoctorController.java
@@ -6,6 +6,7 @@ import com.Major.Project.Service.DoctorService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -16,24 +17,32 @@ public class DoctorController {
     @Autowired
     private DoctorService doctorService;
 
+    @PreAuthorize("hasRole('ADMIN') or hasRole('DOCTOR')")
     @GetMapping
     public List<DoctorDTO> getDoctor(){
         return doctorService.getDoctorList();
     }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('DOCTOR')")
     @GetMapping("/{id}")
     public DoctorDTO getDoctorById(@PathVariable Long id){
         return doctorService.getDoctorListById(id);
     }
+
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping()
     public DoctorDTO saveDoctor(@RequestBody Doctor doctor){
         return doctorService.createDoctor(doctor);
     }
+
+    @PreAuthorize("hasRole('ADMIN')")
     @PutMapping("/{id}")
     public ResponseEntity<DoctorDTO> updateDoctor(@PathVariable Long id,@RequestBody Doctor doctor){
 
         DoctorDTO updated = doctorService.updateDoctor(id, doctor);
         return updated != null ? ResponseEntity.ok(updated) : ResponseEntity.notFound().build();
     }
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteDoctor(@PathVariable Long id){
         doctorService.DeleteDoctor(id);

--- a/src/main/java/com/Major/Project/Controller/InventoryController.java
+++ b/src/main/java/com/Major/Project/Controller/InventoryController.java
@@ -6,6 +6,7 @@ import com.Major.Project.Service.InventoryService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -16,31 +17,44 @@ public class InventoryController {
     @Autowired
     private InventoryService inventoryService;
 
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping
     public List<InventoryDTO> getItems(){
         return inventoryService.getAllItems();
     }
+
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/{inventoryId}")
     public InventoryDTO getItemsById(@PathVariable Long inventoryId){
         return inventoryService.getItemsById(inventoryId);
     }
+
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/status/{status}")
     public List<InventoryDTO> getItemsByStatus(@PathVariable String status){
         return inventoryService.getItemByStatus(status);
     }
+
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/category/{category}")
     public List<InventoryDTO> getItemsByCategory(@PathVariable String category){
         return inventoryService.getItemByCategory(category);
     }
+
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping
     public InventoryDTO createItems(@RequestBody Inventory inventory){
         return inventoryService.createItem(inventory);
     }
+
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{inventoryId}")
     public ResponseEntity<Void> deleteItem(@PathVariable Long inventoryId){
         inventoryService.deleteItem(inventoryId);
         return ResponseEntity.noContent().build();
     }
+
+    @PreAuthorize("hasRole('ADMIN')")
     @PutMapping("/{inventoryId}")
     public ResponseEntity<InventoryDTO> updateItems(@PathVariable Long inventoryId,@RequestBody Inventory inventory){
        InventoryDTO updated= inventoryService.updateItem(inventoryId,inventory);

--- a/src/main/java/com/Major/Project/Controller/LabController.java
+++ b/src/main/java/com/Major/Project/Controller/LabController.java
@@ -6,6 +6,7 @@ import com.Major.Project.Service.LabService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -16,31 +17,44 @@ public class LabController {
     @Autowired
     private LabService labService;
 
+    @PreAuthorize("hasRole('DOCTOR')")
     @GetMapping
     public List<LabTestDTO> getAllLabTest() {
         return labService.getAllLabTest();
     }
+
+    @PreAuthorize("hasRole('DOCTOR') or hasRole('PATIENT')")
     @GetMapping("/{id}")
     public LabTestDTO getLabTestByID(@PathVariable Long id) {
         return labService.getLabTestByID(id);
     }
+
+    @PreAuthorize("hasRole('DOCTOR') or hasRole('PATIENT')")
     @GetMapping("/patient/{patientId}")
     public List<LabTestDTO> getByPatientID(@PathVariable Long patientId){
         return labService.getByPatientId(patientId);
     }
+
+    @PreAuthorize("hasRole('DOCTOR') or hasRole('PATIENT')")
     @GetMapping("/status/{status}")
     public List<LabTestDTO> getByStatus(@PathVariable String status){
         return labService.getByStatus(status);
     }
+
+    @PreAuthorize("hasRole('DOCTOR')")
     @PostMapping
     public LabTestDTO createLabTest(@RequestBody LabTest labTest){
         return labService.createLabTest(labTest);
     }
+
+    @PreAuthorize("hasRole('DOCTOR')")
     @PutMapping("/{id}")
     public ResponseEntity<LabTestDTO> UpdateLabTest(@PathVariable Long id, @RequestBody LabTest labTest){
         LabTestDTO labTest1 = labService.UpdateLabTest(id, labTest);
         return labTest1 != null ? ResponseEntity.ok(labTest1) : ResponseEntity.notFound().build();
     }
+
+    @PreAuthorize("hasRole('DOCTOR')")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteLabTest(@PathVariable Long id){
         labService.deleteLabTest(id);

--- a/src/main/java/com/Major/Project/Controller/MedicineController.java
+++ b/src/main/java/com/Major/Project/Controller/MedicineController.java
@@ -6,6 +6,7 @@ import com.Major.Project.Service.MedicineService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -16,38 +17,45 @@ public class MedicineController {
     @Autowired
     private MedicineService medicineService;
 
+    @PreAuthorize("hasRole('DOCTOR')")
     @GetMapping
     public List<MedicineDTO> getAll() {
         return medicineService.getAll();
     }
 
+    @PreAuthorize("hasRole('DOCTOR')")
     @GetMapping("/{id}")
     public ResponseEntity<MedicineDTO> getById(@PathVariable Long id) {
         MedicineDTO medicine = medicineService.getById(id);
         return medicine != null ? ResponseEntity.ok(medicine) : ResponseEntity.notFound().build();
     }
 
+    @PreAuthorize("hasRole('DOCTOR')")
     @GetMapping("/status/{status}")
     public List<MedicineDTO> getByStatus(@PathVariable String status) {
         return medicineService.getByStatus(status);
     }
 
+    @PreAuthorize("hasRole('DOCTOR')")
     @GetMapping("/search/{name}")
     public List<MedicineDTO> searchByName(@PathVariable String name) {
         return medicineService.searchByName(name);
     }
 
+    @PreAuthorize("hasRole('DOCTOR')")
     @PostMapping
     public ResponseEntity<MedicineDTO> create(@RequestBody Medicine medicine) {
         return ResponseEntity.ok(medicineService.create(medicine));
     }
 
+    @PreAuthorize("hasRole('DOCTOR')")
     @PutMapping("/{id}")
     public ResponseEntity<MedicineDTO> update(@PathVariable Long id, @RequestBody Medicine medicine) {
         MedicineDTO updated = medicineService.update(id, medicine);
         return updated != null ? ResponseEntity.ok(updated) : ResponseEntity.notFound().build();
     }
 
+    @PreAuthorize("hasRole('DOCTOR')")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         medicineService.delete(id);

--- a/src/main/java/com/Major/Project/Controller/PatientController.java
+++ b/src/main/java/com/Major/Project/Controller/PatientController.java
@@ -6,6 +6,7 @@ import com.Major.Project.Service.PatientService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
@@ -15,25 +16,30 @@ public class PatientController {
     @Autowired
     private PatientService patientService;
 
+    @PreAuthorize("hasRole('DOCTOR')")
     @GetMapping
     public List<PatientDTO> getPatient(){
         return patientService.getPatientList();
     }
+    @PreAuthorize("hasRole('DOCTOR') or hasRole('PATIENT')")
     @GetMapping("/{id}")
     public PatientDTO getPatientById(@PathVariable Long id){
         return patientService.getPatientListById(id);
     }
 
+    @PreAuthorize("hasRole('DOCTOR')")
     @PostMapping
     public PatientDTO savePatient(@RequestBody Patient patient){
         return patientService.createPatient(patient);
     }
+    @PreAuthorize("hasRole('DOCTOR')")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deletePatient(@PathVariable Long id) {
         patientService.deletePatient(id);
         return ResponseEntity.noContent().build();
     }
 
+    @PreAuthorize("hasRole('DOCTOR')")
     @PutMapping("/{id}")
     public ResponseEntity<PatientDTO> updatePatient(@PathVariable Long id,@RequestBody Patient patient){
         PatientDTO p=patientService.updatePatient(id,patient);

--- a/src/main/java/com/Major/Project/Controller/StaffController.java
+++ b/src/main/java/com/Major/Project/Controller/StaffController.java
@@ -7,6 +7,7 @@ import com.Major.Project.Service.StaffService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import java.util.List;
 
@@ -15,43 +16,52 @@ import java.util.List;
 public class StaffController {
     @Autowired
     private StaffService staffService;
+
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping
     public List<StaffDTO> getAll() {
         return staffService.getAll();
     }
 
+    @PreAuthorize("hasRole('ADMIN') or hasRole('DOCTOR')")
     @GetMapping("/{id}")
     public ResponseEntity<StaffDTO> getById(@PathVariable Long id) {
         StaffDTO staff = staffService.getById(id);
         return staff != null ? ResponseEntity.ok(staff) : ResponseEntity.notFound().build();
     }
 
+    @PreAuthorize("hasRole('ADMIN') or hasRole('DOCTOR')")
     @GetMapping("/department/{department}")
     public List<StaffDTO> getByDepartment(@PathVariable String department) {
         return staffService.getByDepartment(department);
     }
 
+    @PreAuthorize("hasRole('ADMIN') or hasRole('DOCTOR')")
     @GetMapping("/status/{status}")
     public List<StaffDTO> getByStatus(@PathVariable String status) {
         return staffService.getByStatus(status);
     }
 
+    @PreAuthorize("hasRole('ADMIN') or hasRole('DOCTOR')")
     @GetMapping("/role/{role}")
     public List<StaffDTO> getByRole(@PathVariable String role) {
         return staffService.getByRole(role);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping
     public ResponseEntity<StaffDTO> create(@RequestBody Staff staff) {
         return ResponseEntity.ok(staffService.create(staff));
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @PutMapping("/{id}")
     public ResponseEntity<StaffDTO> update(@PathVariable Long id, @RequestBody Staff staff) {
         StaffDTO updated = staffService.update(id, staff);
         return updated != null ? ResponseEntity.ok(updated) : ResponseEntity.notFound().build();
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         staffService.delete(id);

--- a/src/main/java/com/Major/Project/Security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/Major/Project/Security/JwtAuthenticationFilter.java
@@ -32,7 +32,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String token = authHeader.substring(7);
             try {
                 String username = jwtUtil.validateAndGetUsername(token);
-                // Extract roles from token using JwtUtil
+                
                 List<String> roles = jwtUtil.getRolesFromToken(token);
                 List<SimpleGrantedAuthority> authorities = roles.stream()
                     .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
@@ -41,9 +41,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 UsernamePasswordAuthenticationToken authentication = 
                     new UsernamePasswordAuthenticationToken(username, null, authorities);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
+
             } catch (Exception e) {
-                // Token invalid
-                
+                SecurityContextHolder.clearContext();
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json");
+                response.getWriter().write("{ \"error\": \"Invalid Token\", \"message\": \"" + e.getMessage() + "\" }");
+                return; 
+
             }
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/com/Major/Project/Security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/Major/Project/Security/JwtAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package com.Major.Project.Security;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            try {
+                String username = jwtUtil.validateAndGetUsername(token);
+                // Extract roles from token using JwtUtil
+                List<String> roles = jwtUtil.getRolesFromToken(token);
+                List<SimpleGrantedAuthority> authorities = roles.stream()
+                    .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+                    .collect(Collectors.toList());
+
+                UsernamePasswordAuthenticationToken authentication = 
+                    new UsernamePasswordAuthenticationToken(username, null, authorities);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (Exception e) {
+                // Token invalid
+                
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+}

--- a/src/main/java/com/Major/Project/Security/JwtUtil.java
+++ b/src/main/java/com/Major/Project/Security/JwtUtil.java
@@ -6,7 +6,9 @@ import io.jsonwebtoken.security.Keys;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 
 @Component
 public class JwtUtil {
@@ -14,10 +16,12 @@ public class JwtUtil {
     private final Key key = Keys.hmacShaKeyFor(
             "medimate-super-secret-key-change-this-in-prod-123456".getBytes()
     );
+    List<String> roles = Arrays.asList("ADMIN", "DOCTOR", "PATIENT", "STAFF");
 
-    public String generateToken(String username) {
+    public String generateToken(String username, List<String> roles) {
         return Jwts.builder()
                 .setSubject(username)
+                .claim("roles", roles)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60))
                 .signWith(key)
@@ -32,5 +36,20 @@ public class JwtUtil {
                 .getBody();
 
         return claims.getSubject();
+    }
+
+    public List<String> getRolesFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        Object rolesClaim = claims.get("roles");
+        if (rolesClaim instanceof List<?>) {
+            return ((List<?>) rolesClaim).stream().map(Object::toString).toList();
+        } else if (rolesClaim instanceof String) {
+            return List.of(rolesClaim.toString());
+        }
+        return List.of();
     }
 }

--- a/src/main/java/com/Major/Project/Security/SecurityConfig.java
+++ b/src/main/java/com/Major/Project/Security/SecurityConfig.java
@@ -1,15 +1,24 @@
 package com.Major.Project.Security;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import jakarta.servlet.http.HttpServletResponse;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
+
+    @Autowired
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -18,10 +27,27 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/auth/login").permitAll()
-                .anyRequest().authenticated()
+                .requestMatchers("/HMS/Appointment/**").hasAnyRole("DOCTOR", "PATIENT")
+                .requestMatchers("/HMS/Patient/**").hasAnyRole("PATIENT", "DOCTOR")
+                .requestMatchers("/HMS/Medicine/**").hasAnyRole("DOCTOR")
+                .requestMatchers("/HMS/Staff/**").hasAnyRole("DOCTOR", "ADMIN")
+                .requestMatchers("/HMS/LabTest/**").hasAnyRole("DOCTOR", "PATIENT")
+                .requestMatchers("/HMS/Inventory/**").hasAnyRole("DOCTOR", "ADMIN")
+                .requestMatchers("/HMS/Bill/**").hasAnyRole("DOCTOR", "PATIENT")
+                .requestMatchers("/HMS/Doctor/**").hasAnyRole("DOCTOR")
+                .anyRequest().authenticated()                
             )
-            .httpBasic(Customizer.withDefaults());
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .exceptionHandling(exception -> exception
+            .accessDeniedHandler((request, response, accessDeniedException) -> {
+                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                response.setContentType("application/json");
+                response.getWriter().write("{ \"error\": \"Forbidden\", \"message\": \"Access Denied: You do not have the required permissions.\" }");
+            })
+        )
+        .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
-        return http.build();
-    }
+    return http.build();
+}   
 }


### PR DESCRIPTION
1. Restricted the access to role based for all controllers using @PreAuthorize for Admin, Doctor, Patient as mentioned in the ticket.
2. Enhanced JwtAuthenticationFilter to extract and inject roles from JWT claims into the Spring Security Context
3. Enforced role checks in SecurityConfig .
4. Returns proper HTTP responses for unauthorized access (403 Forbidden).
5. Generated token for different roles to test locally.
6. Tested locally using curl commands for each endpoint to ensure the roles has proper access.